### PR TITLE
Change default operator in the search text parser

### DIFF
--- a/data-showcase/src/main/user-interface/src/app/app.component.spec.ts
+++ b/data-showcase/src/main/user-interface/src/app/app.component.spec.ts
@@ -9,7 +9,7 @@ import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import {TreeNodesComponent} from "./tree-nodes/tree-nodes.component";
 import {
-  AutoCompleteModule, DataTableModule, DialogModule, FieldsetModule, PaginatorModule, PanelModule,
+  AutoCompleteModule, CheckboxModule, DataTableModule, DialogModule, FieldsetModule, PaginatorModule, PanelModule,
   TreeModule
 } from "primeng/primeng";
 import {FormsModule} from "@angular/forms";
@@ -58,7 +58,8 @@ describe('AppComponent', () => {
         DialogModule,
         HttpModule,
         InfoModule,
-        PaginatorModule
+        PaginatorModule,
+        CheckboxModule
       ],
       providers: [
         DataService,

--- a/data-showcase/src/main/user-interface/src/app/item-table/item-table.component.spec.ts
+++ b/data-showcase/src/main/user-interface/src/app/item-table/item-table.component.spec.ts
@@ -9,7 +9,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {ItemFilter, ItemTableComponent} from './item-table.component';
 import {FormsModule} from "@angular/forms";
 import {
-  AutoCompleteModule, DataListModule, DataTableModule, FieldsetModule, ListboxModule, PaginatorModule,
+  AutoCompleteModule, CheckboxModule, DataListModule, DataTableModule, FieldsetModule, ListboxModule, PaginatorModule,
   PanelModule
 } from "primeng/primeng";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
@@ -36,7 +36,8 @@ describe('ItemTableComponent', () => {
         BrowserAnimationsModule,
         DataTableModule,
         HttpModule,
-        PaginatorModule
+        PaginatorModule,
+        CheckboxModule
       ],
       providers: [
         DataService,

--- a/data-showcase/src/main/user-interface/src/app/search-text-parser/grammar.ne
+++ b/data-showcase/src/main/user-interface/src/app/search-text-parser/grammar.ne
@@ -8,7 +8,7 @@
 
 import { syntax } from './syntax';
 
-const defaultOperator = 'and';
+const defaultOperator = 'or';
 
 function stripQuotes(word) {
     return word.value.replace(/^"|"$/g, '');

--- a/data-showcase/src/main/user-interface/src/app/search-text-parser/grammar.ts
+++ b/data-showcase/src/main/user-interface/src/app/search-text-parser/grammar.ts
@@ -12,7 +12,7 @@ declare var WS:any;
 
 import { syntax } from './syntax';
 
-const defaultOperator = 'and';
+const defaultOperator = 'or';
 
 function stripQuotes(word) {
     return word.value.replace(/^"|"$/g, '');

--- a/data-showcase/src/main/user-interface/src/app/search-text-parser/index.spec.ts
+++ b/data-showcase/src/main/user-interface/src/app/search-text-parser/index.spec.ts
@@ -59,8 +59,10 @@ describe('Search text parser', () => {
 
         let result = parser.flatten(tree);
         let expected = {type: 'and', values: [
-            {type: 'string', value :'moo'},
-            {type: 'string', value: 'cow'},
+            {type: 'or', values: [
+              {type: 'string', value: 'moo'},
+              {type: 'string', value: 'cow'}
+            ]},
             {type: 'or', values: [
                 {type: 'string', value: 'bla'},
                 {type: 'string', value: 'this'}
@@ -131,10 +133,11 @@ describe('Search text parser', () => {
 
         let result = parser.flatten(tree);
         let expected = {type: 'and', values: [
-            {type: 'string', value: 'cow'},
-            {type: 'string', value: 'goose'},
-            {type: 'string', value: 'sheep'}
-        ]} as SearchQuery;
+            {type: 'or', values :[
+                {type: 'string', value: 'cow'},
+                {type: 'string', value: 'goose'},
+                {type: 'string', value: 'sheep'}
+        ]}]} as SearchQuery;
 
         expect(JSON.stringify(result)).toEqual(JSON.stringify(expected));
     });
@@ -147,7 +150,7 @@ describe('Search text parser', () => {
         expect(tree).not.toBeNull();
 
         let result = parser.flatten(tree);
-        let expected = {type: 'and', values: [
+        let expected = {type: 'or', values: [
             {type: 'string', value: 'cow'},
             {type: '!=', value: 'label', values: [
                 {type: 'string', value: 'goose'}


### PR DESCRIPTION
If no operator specified, OR will be used by default (instead of AND)