### PR TITLE
Fix a search field issue: operators 'like' and '=' seem to do the same

### DIFF
--- a/data-showcase/src/main/groovy/nl/thehyve/datashowcase/search/SearchCriteriaBuilder.groovy
+++ b/data-showcase/src/main/groovy/nl/thehyve/datashowcase/search/SearchCriteriaBuilder.groovy
@@ -56,9 +56,9 @@ class SearchCriteriaBuilder {
             case Operator.CONTAINS:
                 return Restrictions.ilike(propertyName, value as String, MatchMode.ANYWHERE)
             case Operator.EQUALS:
-                return Restrictions.ilike(propertyName, value as String, MatchMode.EXACT)
+                return Restrictions.eq(propertyName, value as String).ignoreCase()
             case Operator.NOT_EQUALS:
-                return Restrictions.not(Restrictions.ilike(propertyName, value as String, MatchMode.EXACT))
+                return Restrictions.not(Restrictions.eq(propertyName, value as String).ignoreCase())
             case Operator.LIKE:
                 return Restrictions.ilike(propertyName, value as String)
             default:


### PR DESCRIPTION
NTRDEV-266

'ilike' hibernate restriction with match mode = "Exact" is accepting
wildcards. Replaced with 'eq' restriction with ignoreCase() method.